### PR TITLE
Labeled variables

### DIFF
--- a/include/BetterSerialPlotter/BSP.hpp
+++ b/include/BetterSerialPlotter/BSP.hpp
@@ -79,6 +79,7 @@ public:
     std::optional<std::reference_wrapper<ScrollingData>> get_data(char identifier);
     /// appends the vector of current data to the current data set. Need to make sure that this is working for any size of data
     void append_all_data(std::vector<float> curr_data);
+    void append_all_data(std::vector<NamedSerialData> curr_data);
 
     std::string get_name(char identifier);
     ImVec4 get_color(char identifier);

--- a/include/BetterSerialPlotter/BSP.hpp
+++ b/include/BetterSerialPlotter/BSP.hpp
@@ -39,7 +39,7 @@ public:
     // std::vector<std::string> data_names;
     // std::vector<ImVec4> data_colors;
 
-    std::unordered_map<char,DataInfo> all_data_info;
+    std::unordered_map<std::string,DataInfo> all_data_info;
     
     // HANDLE hSerial;
 
@@ -76,13 +76,13 @@ public:
     ~BSP();
     void update();
     /// returns an optional reference wrapper to a scrolling data object. This returns the data corresponding to the requested identifier if available, or nullopt otherwise
-    std::optional<std::reference_wrapper<ScrollingData>> get_data(char identifier);
+    std::optional<std::reference_wrapper<ScrollingData>> get_data(std::string identifier);
     /// appends the vector of current data to the current data set. Need to make sure that this is working for any size of data
     void append_all_data(std::vector<float> curr_data);
     void append_all_data(std::vector<NamedSerialData> curr_data);
 
-    std::string get_name(char identifier);
-    ImVec4 get_color(char identifier);
+    std::string get_name(std::string identifier);
+    ImVec4 get_color(std::string identifier);
 
     void serialize();
     void deserialize();

--- a/include/BetterSerialPlotter/Plot.hpp
+++ b/include/BetterSerialPlotter/Plot.hpp
@@ -22,26 +22,26 @@ public:
     /// actually plots the data that goes on the plot
     void plot_data();
     /// adds a unique identifier to this plot, adding the variable to the dsiplay
-    void add_identifier(char identifier, int y_axis_num = 0);
+    void add_identifier(std::string identifier, int y_axis_num = 0);
     /// removes a unique identifier to this plot, removing the variable from the display
-    void remove_identifier(char identifier);
+    void remove_identifier(std::string identifier);
     /// checks if a unique identifier is used on this plot
-    bool has_identifier(char identifier) const;
+    bool has_identifier(std::string identifier) const;
     /// sets all_plot_paused_data and paused_x_axis to current data
     void update_paused_data();
     /// returns the data corresponding to a specific identifier
-    std::optional<std::reference_wrapper<ScrollingData>> get_data(char identifier);
+    std::optional<std::reference_wrapper<ScrollingData>> get_data(std::string identifier);
     /// vector of all identifiers for this plot
-    std::vector<char> all_plot_data;
+    std::vector<std::string> all_plot_data;
     
     /// saved paused data for all variables on this plot
     std::vector<ScrollingData> all_plot_paused_data;
 
     bool other_x_axis = false; // indicates that x-axis for this plot is something other than this program time
     bool x_axis_realtime = true; // indicates that x-axis for this plot corresponds to something realtime, meaning that we want it to scroll with the 
-    char x_axis = -1;
+    std::string x_axis = "-1";
     ScrollingData paused_x_axis;
-    std::unordered_map<char,int> y_axis;
+    std::unordered_map<std::string,int> y_axis;
     bool is_resizing = false;
     float time_frame = 10.0f;
     float paused_x_axis_modifier = 0.1f;

--- a/include/BetterSerialPlotter/SerialManager.hpp
+++ b/include/BetterSerialPlotter/SerialManager.hpp
@@ -66,7 +66,7 @@ public:
     /// parses a buffer received from a serial port read
     void parse_buffer(unsigned char* message, size_t buff_len);
     /// parses a single line received from the buffer
-    std::vector<float> parse_line(std::string line);
+    std::vector<float> parse_unnamed_data_line(std::string line);
 
     bool comport_valid();
 

--- a/include/BetterSerialPlotter/SerialManager.hpp
+++ b/include/BetterSerialPlotter/SerialManager.hpp
@@ -3,6 +3,7 @@
 #include <BetterSerialPlotter/Widget.hpp>
 #include <Mahi/Com/SerialPort.hpp>
 #include <mutex>
+#include "Utility.hpp"
 
 namespace bsp{
 
@@ -65,8 +66,10 @@ public:
     std::string get_port_name(BspPort port_num);
     /// parses a buffer received from a serial port read
     void parse_buffer(unsigned char* message, size_t buff_len);
-    /// parses a single line received from the buffer
+    /// parses a single line with unnamed data received from the buffer
     std::vector<float> parse_unnamed_data_line(std::string line);
+    /// parses a single line with named data received from the buffer
+    std::vector<NamedSerialData> parse_named_data_line(std::string line);
 
     bool comport_valid();
 

--- a/include/BetterSerialPlotter/Serialization.hpp
+++ b/include/BetterSerialPlotter/Serialization.hpp
@@ -42,7 +42,7 @@ struct BSPData{
     std::vector<ScrollingData> all_data;
     SerialManager serial_manager;
     PlotMonitor plot_monitor;
-    std::unordered_map<char,DataInfo> all_data_info;
+    std::unordered_map<std::string,DataInfo> all_data_info;
 };
 
 // all of these need to be in the bsp namespace because the to_json

--- a/include/BetterSerialPlotter/Utility.hpp
+++ b/include/BetterSerialPlotter/Utility.hpp
@@ -71,6 +71,11 @@ struct DataInfo {
      void set_identifier(char identifier){identifier = identifier;}
 };
 
+struct NamedSerialData {
+    std::string name;
+    float data;
+};
+
 // void plot_data(const ScrollingData &data, int i);
 #ifdef __APPLE__
 std::vector<std::string> get_serial_ports();

--- a/include/BetterSerialPlotter/Utility.hpp
+++ b/include/BetterSerialPlotter/Utility.hpp
@@ -12,7 +12,7 @@ namespace bsp{
 
 // data structure to handle a single variable coming in from serial
 struct ScrollingData {
-     char identifier = 0;   // unique identifier that can be used to pull this data
+     std::string identifier;   // unique identifier that can be used to pull this data
      int MaxSize = 5000;    // maximum amount of data points that will be stored
      int Offset  = 0;       // offset to handle plotting
      ImVector<ImVec2> Data; // vector of x and y data. X data always is time
@@ -58,7 +58,7 @@ struct ScrollingData {
      }
 
      /// set the identifier
-     void set_identifier(char identifier){identifier = identifier;}
+     void set_identifier(std::string identifier){identifier = identifier;}
 };
 
 struct DataInfo {

--- a/src/BetterSerialPlotter/BSP.cpp
+++ b/src/BetterSerialPlotter/BSP.cpp
@@ -103,20 +103,16 @@ void BSP::append_all_data(std::vector<float> curr_data){
     std::lock_guard<std::mutex> lock(serial_manager.mtx);
 
     auto old_size = mutexed_all_data.size();
-    if (old_size != curr_data.size()){
-        if (old_size < curr_data.size()){
-            for (int i = old_size; i < curr_data.size(); i++){
-                mutexed_all_data.emplace_back();
-                mutexed_all_data[i].identifier = old_size+i;
-                if (all_data_info.find(mutexed_all_data[i].identifier) == all_data_info.end()){
-                    all_data_info[mutexed_all_data[i].identifier].set_name("data " + std::to_string(i));
-                    all_data_info[mutexed_all_data[i].identifier].color = plot_colors[i%plot_colors.size()];
-                }
-            }
-        }
-        else{
-            for (auto i = old_size-1; i > old_size - curr_data.size(); i--){
-                mutexed_all_data.erase(mutexed_all_data.begin()+i);
+    if (old_size < curr_data.size()){
+        for (int i = old_size; i < curr_data.size(); i++){
+            ScrollingData new_data;
+            std::string new_identifier = "data " + old_size+i;
+            new_data.identifier = new_identifier;
+
+            mutexed_all_data.emplace_back(new_data);
+            if (all_data_info.find(new_identifier) == all_data_info.end()){
+                all_data_info[new_identifier].set_name("data " + std::to_string(i));
+                all_data_info[new_identifier].color = plot_colors[i%plot_colors.size()];
             }
         }
     }

--- a/src/BetterSerialPlotter/BSP.cpp
+++ b/src/BetterSerialPlotter/BSP.cpp
@@ -135,7 +135,7 @@ void BSP::append_all_data(std::vector<NamedSerialData> curr_data){
     }
 }
 
-std::optional<std::reference_wrapper<ScrollingData>> BSP::get_data(char identifier){
+std::optional<std::reference_wrapper<ScrollingData>> BSP::get_data(std::string identifier){
     for (auto &data : all_data){
         if (data.identifier == identifier){
             return data;
@@ -145,12 +145,12 @@ std::optional<std::reference_wrapper<ScrollingData>> BSP::get_data(char identifi
     return std::nullopt; //ScrollingData();
 }
 
-std::string BSP::get_name(char identifier){
+std::string BSP::get_name(std::string identifier){
     auto found_it = all_data_info.find(identifier);
     return (found_it != all_data_info.end()) ? found_it->second.name : "";
 }
 
-ImVec4 BSP::get_color(char identifier){
+ImVec4 BSP::get_color(std::string identifier){
     auto found_it = all_data_info.find(identifier);
     return (found_it != all_data_info.end()) ? found_it->second.color : ImVec4(0.0f, 0.0f, 0.0f, 1.0f);
 }

--- a/src/BetterSerialPlotter/BSP.cpp
+++ b/src/BetterSerialPlotter/BSP.cpp
@@ -129,6 +129,12 @@ void BSP::append_all_data(std::vector<float> curr_data){
     // std::cout << "end append\n";
 }
 
+void BSP::append_all_data(std::vector<NamedSerialData> curr_data){
+    for (const auto& data : curr_data) {
+        std::cout << "Name: " << data.name << ", Data: " << data.data << "\n";
+    }
+}
+
 std::optional<std::reference_wrapper<ScrollingData>> BSP::get_data(char identifier){
     for (auto &data : all_data){
         if (data.identifier == identifier){

--- a/src/BetterSerialPlotter/Plot.cpp
+++ b/src/BetterSerialPlotter/Plot.cpp
@@ -266,7 +266,7 @@ void Plot::plot_data(){
     
 }
 
-void Plot::add_identifier(char identifier, int y_axis_num){
+void Plot::add_identifier(std::string identifier, int y_axis_num){
     bool exists = false;
     // check if it is already there
     for (const auto &i : all_plot_data){
@@ -282,7 +282,7 @@ void Plot::add_identifier(char identifier, int y_axis_num){
     y_axis[identifier] = y_axis_num;
 }
 
-void Plot::remove_identifier(char identifier){
+void Plot::remove_identifier(std::string identifier){
     // look for the identifier in the identifiers vector
     for (auto i = all_plot_data.begin(); i != all_plot_data.end(); i++){
         if (*i == identifier) {
@@ -300,14 +300,14 @@ void Plot::remove_identifier(char identifier){
     }
 }
 
-bool Plot::has_identifier(char identifier) const{
+bool Plot::has_identifier(std::string identifier) const{
     for (const auto &data : all_plot_data){
         if (data == identifier) return true;
     }
     return false;
 }
 
-std::optional<std::reference_wrapper<ScrollingData>> Plot::get_data(char identifier){
+std::optional<std::reference_wrapper<ScrollingData>> Plot::get_data(std::string identifier){
     return plot_monitor->gui->get_data(identifier);
 }
 

--- a/test/line_parse_test.cpp
+++ b/test/line_parse_test.cpp
@@ -5,7 +5,7 @@
     TEST(line_parsing, name){\
         auto str_num = strings[num];\
         auto num_num = numbers[num];\
-        auto parse_result = sm.parse_line(str_num);\
+        auto parse_result = sm.parse_unnamed_data_line(str_num);\
         EXPECT_EQ(parse_result[0], num_num);\
     }
 
@@ -57,7 +57,7 @@ TEST(line_parsing, tab_delimited){
         if (i != test_string.size()-1) test_string += "\t";
     }
 
-    auto parse_result = sm.parse_line(test_string);
+    auto parse_result = sm.parse_unnamed_data_line(test_string);
     EXPECT_EQ(parse_result,numbers);
 }
 
@@ -68,7 +68,7 @@ TEST(line_parsing, space_delimited){
         if (i != test_string.size()-1) test_string += " ";
     }
 
-    auto parse_result = sm.parse_line(test_string);
+    auto parse_result = sm.parse_unnamed_data_line(test_string);
     EXPECT_EQ(parse_result,numbers);
 }
 
@@ -79,14 +79,14 @@ TEST(line_parsing, both_delimited){
         if (i != test_string.size()-1) test_string += (i%2) ? "\t" : " ";
     }
 
-    auto parse_result = sm.parse_line(test_string);
+    auto parse_result = sm.parse_unnamed_data_line(test_string);
     EXPECT_EQ(parse_result,numbers);
 }
 
 TEST(line_parsing, combined_numbers){
     std::string combined_numbers = "0.10.2";
 
-    auto parse_result = sm.parse_line(combined_numbers);
+    auto parse_result = sm.parse_unnamed_data_line(combined_numbers);
     EXPECT_EQ(parse_result.size(),0);
 }
 
@@ -94,7 +94,7 @@ TEST(line_parsing, one_combined_number){
     std::string combined_numbers = "1.23 0.10.2 1.3e7";
     std::vector<float> float_result = {1.23f, 1.3e7f};
 
-    auto parse_result = sm.parse_line(combined_numbers);
+    auto parse_result = sm.parse_unnamed_data_line(combined_numbers);
     EXPECT_EQ(parse_result, float_result);
 }
 
@@ -102,6 +102,6 @@ TEST(line_parsing, extra_spaces){
     std::string combined_numbers = "  1.23 1.3e7   ";
     std::vector<float> float_result = {1.23f, 1.3e7f};
 
-    auto parse_result = sm.parse_line(combined_numbers);
+    auto parse_result = sm.parse_unnamed_data_line(combined_numbers);
     EXPECT_EQ(parse_result, float_result);
 }


### PR DESCRIPTION
This PR resolves https://github.com/nathandunk/BetterSerialPlotter/issues/22 so that labeled variables are supported as in the Arduino plotter.  
In addition, the plotter does not try to parse random text lines anymore which led to weird graphs.  
Another change is not to remove unlabeled data points anymore if the new unlabeled data vector is smaller than before. This make the behavior of BetterSerialPlotter closer to the one of the Arduino IDE.